### PR TITLE
Create JWT Verification Middleware

### DIFF
--- a/server/shared/auth/index.js
+++ b/server/shared/auth/index.js
@@ -1,38 +1,17 @@
 'use strict';
 
 const Audience = require('./audience');
-const { auth: { secret } } = require('../../config');
 const { FORBIDDEN } = require('../errors/status');
-const HttpError = require('../errors/httpError');
-const jwt = require('jsonwebtoken');
-const { User } = require('../database');
+const jwtVerifier = require('./jwtVerifier');
 
-const msg = {
-  ACCESS_FORBIDDEN: 'Your access to this resource is forbidden',
-  TOKEN_INVALID: 'Token is invalid',
-  TOKEN_EXPIRED: 'Token is expired'
-};
+const extractJwt = req => req.cookies.accessToken;
+const ACCESS_FORBIDDEN_MESSAGE = 'Your access to this resource is forbidden';
 
-async function authenticate(req, _, next) {
-  const token = req.cookies.accessToken;
-  if (!token) throw new HttpError(FORBIDDEN, msg.ACCESS_FORBIDDEN);
-  try {
-    const { id, aud } = jwt.verify(token, secret);
-    if (aud !== Audience.Scope.Access) {
-      throw new HttpError(FORBIDDEN, msg.TOKEN_INVALID);
-    }
-    const user = await User.findByPk(id);
-    req.user = user;
-    next();
-  } catch (err) {
-    if (err instanceof jwt.JsonWebTokenError) {
-      throw new HttpError(FORBIDDEN, msg.TOKEN_INVALID);
-    }
-    if (err instanceof jwt.TokenExpiredError) {
-      throw new HttpError(FORBIDDEN, msg.TOKEN_EXPIRED);
-    }
-    throw err;
-  }
-}
+const authenticate = jwtVerifier(
+  extractJwt,
+  Audience.Scope.Access,
+  FORBIDDEN,
+  ACCESS_FORBIDDEN_MESSAGE
+);
 
 module.exports = authenticate;

--- a/server/shared/auth/jwtVerifier.js
+++ b/server/shared/auth/jwtVerifier.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { auth: { secret } } = require('../../config');
+const HttpError = require('../errors/httpError');
+const jwt = require('jsonwebtoken');
+const { NOT_FOUND } = require('../errors/status');
+const { User } = require('../database');
+
+function jwtVerifier(extractJwt, jwtAudience, errorCode, errorMessage) {
+  const msg = {
+    TOKEN_INVALID: 'Token is invalid.',
+    TOKEN_EXPIRED: 'Token is expired.',
+    USER_NOT_FOUND: 'User not found.'
+  };
+
+  return async (req, _, next) => {
+    const token = extractJwt(req);
+    if (!token) {
+      throw new HttpError(errorCode, errorMessage || msg.TOKEN_INVALID);
+    }
+    try {
+      const { id, aud } = jwt.verify(token, secret);
+      if (aud !== jwtAudience) {
+        throw new HttpError(errorCode, msg.TOKEN_INVALID);
+      }
+      const user = await User.findByPk(id);
+      if (!user) {
+        throw new HttpError(NOT_FOUND, msg.USER_NOT_FOUND);
+      }
+      req.user = user;
+      return next();
+    } catch (err) {
+      if (err instanceof jwt.JsonWebTokenError) {
+        throw new HttpError(errorCode, msg.TOKEN_INVALID);
+      }
+      if (err instanceof jwt.TokenExpiredError) {
+        throw new HttpError(errorCode, msg.TOKEN_EXPIRED);
+      }
+      throw err;
+    }
+  };
+}
+
+module.exports = jwtVerifier;

--- a/server/shared/auth/verify.js
+++ b/server/shared/auth/verify.js
@@ -1,34 +1,15 @@
 'use strict';
 
-const { auth: { secret } } = require('../../config');
 const Audience = require('./audience');
 const { BAD_REQUEST } = require('../errors/status');
-const HttpError = require('../errors/httpError');
-const jwt = require('jsonwebtoken');
+const jwtVerifier = require('./jwtVerifier');
 
-const msg = {
-  TOKEN_INVALID: 'Token is invalid',
-  TOKEN_EXPIRED: 'Token is expired'
-};
+const extractJwt = req => req.params.token || req.body.token;
 
-function verify(req, _, next) {
-  const token = req.params.token || req.body.token;
-  try {
-    const { id, aud } = jwt.verify(token, secret);
-    if (aud !== Audience.Scope.Setup) {
-      throw new HttpError(BAD_REQUEST, msg.TOKEN_INVALID);
-    }
-    req.id = id;
-    return next();
-  } catch (err) {
-    if (err instanceof jwt.JsonWebTokenError) {
-      throw new HttpError(BAD_REQUEST, msg.TOKEN_INVALID);
-    }
-    if (err instanceof jwt.TokenExpiredError) {
-      throw new HttpError(BAD_REQUEST, msg.TOKEN_EXPIRED);
-    }
-    throw err;
-  }
-}
+const verify = jwtVerifier(
+  extractJwt,
+  Audience.Scope.Setup,
+  BAD_REQUEST
+);
 
 module.exports = verify;

--- a/server/user/user.controller.js
+++ b/server/user/user.controller.js
@@ -38,9 +38,7 @@ async function register({ body }, res) {
   return res.status(CREATED).json({ message: msg.SUCCESS_REGISTER });
 }
 
-async function verify({ id }, res) {
-  const user = await User.findByPk(id);
-  if (!user) throw new HttpError(NOT_FOUND, msg.USER_NOT_FOUND);
+async function verify({ user }, res) {
   if (user.active) throw new HttpError(CONFLICT, msg.ALREADY_VERIFIED);
   user.active = true;
   await user.save();
@@ -92,9 +90,7 @@ async function forgotPassword({ body }, res) {
   });
 }
 
-async function resetPassword({ body: { password }, id }, res) {
-  const user = await User.findByPk(id);
-  if (!user) throw new HttpError(NOT_FOUND, msg.USER_NOT_FOUND);
+async function resetPassword({ body: { password }, user }, res) {
   user.password = password;
   await user.save();
   return res.status(OK).json({


### PR DESCRIPTION
THIS PR:

Extract common JWT verification logic into separate function with dependency injection in order to be able to reuse it for setup and access tokens. Adapt controller functions called as `next()` to changes where needed.

Closes #46 